### PR TITLE
:bug: fix missing getter on MessageResponse

### DIFF
--- a/src/main/java/io/rocketbase/mail/dto/MessageResponse.java
+++ b/src/main/java/io/rocketbase/mail/dto/MessageResponse.java
@@ -1,7 +1,10 @@
 package io.rocketbase.mail.dto;
 
+import lombok.Getter;
+
 import java.util.Date;
 
+@Getter
 public class MessageResponse {
 
     private String to;


### PR DESCRIPTION
The `MessageResponse` class has no getter and private fields. This PR fix the missing Lombok annotation. Please release a new version with this change. Thank you for the library!